### PR TITLE
expand ci pipeline

### DIFF
--- a/.ci/pipelines/thumbnails4j.groovy
+++ b/.ci/pipelines/thumbnails4j.groovy
@@ -21,7 +21,7 @@
 
 
 // Loading the shared lib
-@Library(['estc', 'entsearch']) _
+@Library(['estc', 'entsearch@tarekziade/NoSuchMethod']) _
 
 eshPipeline(
     timeout: 45,

--- a/.ci/pipelines/thumbnails4j.groovy
+++ b/.ci/pipelines/thumbnails4j.groovy
@@ -19,23 +19,14 @@
  *
  */
 
-// Loading the shared lib
-@Library(['estc', 'entsearch']) _
-
-// Calling the pipeline against the `rubocop` stage
-eshPipeline(
-    timeout: 45,
-    project_name: 'Thumbnails4j',
-    repository: 'thumbnails4j',
-    stage_name: 'Thumbnails4j Unit Tests',
-    stages: [
-      [
-          name: 'Maven Build',
-          type: 'sh',
-          label: 'Maven Build',
-          script: './mvnw clean verify',
-          match_on_all_branches: true,
-      ]
-    ],
-    slack_channel: 'workplace-search-connectors'
-)
+pipeline {
+    agent any
+    stages {
+        stage ('Build and Test') {
+            git url: 'https://github.com/elastic/thumbnails4j'
+            withMaven {
+                sh "mvn clean verify"
+            } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe reports and FindBugs reports
+        }
+    }
+}

--- a/.ci/pipelines/thumbnails4j.groovy
+++ b/.ci/pipelines/thumbnails4j.groovy
@@ -35,7 +35,7 @@ pipeline {
         stage ('Build and Test') {
             steps {
                 withMaven {
-                    sh "mvn clean verify"
+                    sh "./mvnw clean verify"
                 } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe reports and FindBugs reports
             }
         }

--- a/.ci/pipelines/thumbnails4j.groovy
+++ b/.ci/pipelines/thumbnails4j.groovy
@@ -21,7 +21,7 @@
 
 
 // Loading the shared lib
-@Library(['estc', 'entsearch@tarekziade/NoSuchMethod']) _
+@Library(['estc', 'entsearch']) _
 
 eshPipeline(
     timeout: 45,

--- a/.ci/pipelines/thumbnails4j.groovy
+++ b/.ci/pipelines/thumbnails4j.groovy
@@ -19,14 +19,25 @@
  *
  */
 
+
+// Loading the shared lib
+@Library('estc') _
+
 pipeline {
-    agent any
+    agent { label('linux && immutable') }
     stages {
+        stage('Setup') {
+            steps {
+                estcGithubCheckout(repository: 'thumbnails4j',
+                        revision: 'seanstory/expand-ci-pipeline')
+            }
+        }
         stage ('Build and Test') {
-            git url: 'https://github.com/elastic/thumbnails4j'
-            withMaven {
-                sh "mvn clean verify"
-            } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe reports and FindBugs reports
+            steps {
+                withMaven {
+                    sh "mvn clean verify"
+                } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe reports and FindBugs reports
+            }
         }
     }
 }

--- a/.ci/pipelines/thumbnails4j.groovy
+++ b/.ci/pipelines/thumbnails4j.groovy
@@ -21,23 +21,25 @@
 
 
 // Loading the shared lib
-@Library('estc') _
+@Library(['estc', 'entsearch']) _
 
-pipeline {
-    agent { label('linux && immutable') }
-    stages {
-        stage('Setup') {
-            steps {
-                estcGithubCheckout(repository: 'thumbnails4j',
-                        revision: 'main')
-            }
-        }
-        stage ('Build and Test') {
-            steps {
+eshPipeline(
+    timeout: 45,
+    project_name: 'Thumbnails4j',
+    repository: 'thumbnails4j',
+    stage_name: 'Thumbnails4j Unit Tests',
+    stages: [
+        [
+            name: 'Maven Build',
+            type: 'script',
+            label: 'Maven Build',
+            script: {
                 withMaven {
-                    sh "./mvnw clean verify"
-                } // withMaven will discover the generated Maven artifacts, JUnit Surefire & FailSafe reports and FindBugs reports
-            }
-        }
-    }
-}
+                    sh './mvnw clean verify'
+                }
+            },
+            match_on_all_branches: true,
+        ]
+    ],
+    slack_channel: 'workplace-search-connectors'
+)

--- a/.ci/pipelines/thumbnails4j.groovy
+++ b/.ci/pipelines/thumbnails4j.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Setup') {
             steps {
                 estcGithubCheckout(repository: 'thumbnails4j',
-                        revision: 'seanstory/expand-ci-pipeline')
+                        revision: 'main')
             }
         }
         stage ('Build and Test') {


### PR DESCRIPTION
This version of the CI pipeline actually attaches artifacts and parses the test output. It _does_ required the [Pipeline Maven Integration](https://plugins.jenkins.io/pipeline-maven/#installation) plugin to be installed.