### PR TITLE
Add jaxb and jakarta deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,8 @@
         <poi.version>4.1.2</poi.version>
         <xdocreport.version>2.0.2</xdocreport.version>
         <pdfbox.version>2.0.24</pdfbox.version>
+        <jakarta.version>2.3.2</jakarta.version>
+        <jaxb.version>2.3.2</jaxb.version>
 
         <groovy.version>3.0.8</groovy.version>
         <spock.version>2.0-groovy-3.0</spock.version>
@@ -118,6 +120,16 @@
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
                 <version>${pdfbox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb.version}</version>
             </dependency>
 
             <!-- test dependencies -->
@@ -168,6 +180,18 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                        <version>${jaxb.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/thumbnails4j-all/NOTICE.txt
+++ b/thumbnails4j-all/NOTICE.txt
@@ -16,6 +16,8 @@ Third party libraries used by thumbnails4j-all:
   Apache PDFBox under Apache License, Version 2.0
   Apache POI under Apache License, Version 2.0
   curvesapi under BSD License
+  Extended StAX API under Eclipse Distribution License - v 1.0
+  fastinfoset under Apache License, Version 2.0 or Eclipse Distribution License - v 1.0
   fr.opensagres.poi.xwpf.converter.core under The MIT License (MIT)
   fr.opensagres.poi.xwpf.converter.pdf under The MIT License (MIT)
   fr.opensagres.poi.xwpf.converter.xhtml under The MIT License (MIT)
@@ -23,6 +25,10 @@ Third party libraries used by thumbnails4j-all:
   fr.opensagres.xdocreport.converter.docx.xwpf under The MIT License (MIT)
   fr.opensagres.xdocreport.core under The MIT License (MIT)
   fr.opensagres.xdocreport.itext.extension under The MIT License (MIT)
+  istack common utility code runtime under Eclipse Distribution License - v 1.0
+  jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
+  JavaBeans Activation Framework API jar under EDL 1.0
+  JAXB Runtime under Eclipse Distribution License - v 1.0
   OOXML schemas under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
   SparseBitSet under The Apache Software License, Version 2.0
@@ -34,5 +40,6 @@ Third party libraries used by thumbnails4j-all:
   thumbnails4j-pptx under The Apache Software License, Version 2.0
   thumbnails4j-xls under The Apache Software License, Version 2.0
   thumbnails4j-xlsx under The Apache Software License, Version 2.0
+  TXW2 Runtime under Eclipse Distribution License - v 1.0
   XmlBeans under The Apache Software License, Version 2.0
 

--- a/thumbnails4j-all/src/main/resources/META-INF/NOTICE.txt
+++ b/thumbnails4j-all/src/main/resources/META-INF/NOTICE.txt
@@ -16,6 +16,8 @@ Third party libraries used by thumbnails4j-all:
   Apache PDFBox under Apache License, Version 2.0
   Apache POI under Apache License, Version 2.0
   curvesapi under BSD License
+  Extended StAX API under Eclipse Distribution License - v 1.0
+  fastinfoset under Apache License, Version 2.0 or Eclipse Distribution License - v 1.0
   fr.opensagres.poi.xwpf.converter.core under The MIT License (MIT)
   fr.opensagres.poi.xwpf.converter.pdf under The MIT License (MIT)
   fr.opensagres.poi.xwpf.converter.xhtml under The MIT License (MIT)
@@ -23,6 +25,10 @@ Third party libraries used by thumbnails4j-all:
   fr.opensagres.xdocreport.converter.docx.xwpf under The MIT License (MIT)
   fr.opensagres.xdocreport.core under The MIT License (MIT)
   fr.opensagres.xdocreport.itext.extension under The MIT License (MIT)
+  istack common utility code runtime under Eclipse Distribution License - v 1.0
+  jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
+  JavaBeans Activation Framework API jar under EDL 1.0
+  JAXB Runtime under Eclipse Distribution License - v 1.0
   OOXML schemas under The Apache Software License, Version 2.0
   SLF4J API Module under MIT License
   SparseBitSet under The Apache Software License, Version 2.0
@@ -34,5 +40,6 @@ Third party libraries used by thumbnails4j-all:
   thumbnails4j-pptx under The Apache Software License, Version 2.0
   thumbnails4j-xls under The Apache Software License, Version 2.0
   thumbnails4j-xlsx under The Apache Software License, Version 2.0
+  TXW2 Runtime under Eclipse Distribution License - v 1.0
   XmlBeans under The Apache Software License, Version 2.0
 

--- a/thumbnails4j-pptx/NOTICE.txt
+++ b/thumbnails4j-pptx/NOTICE.txt
@@ -12,8 +12,15 @@ Third party libraries used by thumbnails4j-pptx:
   Apache Commons Math under Apache License, Version 2.0
   Apache POI under Apache License, Version 2.0
   curvesapi under BSD License
+  Extended StAX API under Eclipse Distribution License - v 1.0
+  fastinfoset under Apache License, Version 2.0 or Eclipse Distribution License - v 1.0
+  istack common utility code runtime under Eclipse Distribution License - v 1.0
+  jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
+  JavaBeans Activation Framework API jar under EDL 1.0
+  JAXB Runtime under Eclipse Distribution License - v 1.0
   SLF4J API Module under MIT License
   SparseBitSet under The Apache Software License, Version 2.0
   thumbnails4j-core under The Apache Software License, Version 2.0
+  TXW2 Runtime under Eclipse Distribution License - v 1.0
   XmlBeans under The Apache Software License, Version 2.0
 

--- a/thumbnails4j-pptx/pom.xml
+++ b/thumbnails4j-pptx/pom.xml
@@ -26,6 +26,14 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/thumbnails4j-pptx/src/main/resources/META-INF/NOTICE.txt
+++ b/thumbnails4j-pptx/src/main/resources/META-INF/NOTICE.txt
@@ -12,8 +12,15 @@ Third party libraries used by thumbnails4j-pptx:
   Apache Commons Math under Apache License, Version 2.0
   Apache POI under Apache License, Version 2.0
   curvesapi under BSD License
+  Extended StAX API under Eclipse Distribution License - v 1.0
+  fastinfoset under Apache License, Version 2.0 or Eclipse Distribution License - v 1.0
+  istack common utility code runtime under Eclipse Distribution License - v 1.0
+  jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
+  JavaBeans Activation Framework API jar under EDL 1.0
+  JAXB Runtime under Eclipse Distribution License - v 1.0
   SLF4J API Module under MIT License
   SparseBitSet under The Apache Software License, Version 2.0
   thumbnails4j-core under The Apache Software License, Version 2.0
+  TXW2 Runtime under Eclipse Distribution License - v 1.0
   XmlBeans under The Apache Software License, Version 2.0
 


### PR DESCRIPTION
Both the notice plugin and the PPTX thumbnailer require JAXB.
It was present in the default JDK in java 8, but by java 11 has
been pulled out and needs to be depended upon explicitly. See
https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception