### PR TITLE
Remove reference-repo from thumbnails4j.yml

### DIFF
--- a/.ci/jobs/thumbnails4j.yml
+++ b/.ci/jobs/thumbnails4j.yml
@@ -12,7 +12,6 @@
       - github:
           repo: thumbnails4j
           repo-owner: elastic
-          reference-repo: /var/lib/jenkins/.git-references/thumbnails4j.git
           disable-pr-notifications: true
           branch-discovery: all
           discover-pr-origin: current


### PR DESCRIPTION
As discussed with @tarekziade, `reference-repo` is redundant in the definition of `thumbnails4j.yml`.

This PR aims to remove this line from the job configuration.