### PR TITLE
Use try-with-resources to auto-close inputs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+                <configuration>
+                    <!-- to prevent the ForkedBooter process from stealing the window focus on Mac OS -->
+                    <argLine>-Djava.awt.headless=true</argLine>
+                </configuration>
             </plugin>
 
             <!-- requirements for releasing to maven central -->

--- a/thumbnails4j-doc/src/main/java/co/elastic/thumbnails4j/doc/DOCThumbnailer.java
+++ b/thumbnails4j-doc/src/main/java/co/elastic/thumbnails4j/doc/DOCThumbnailer.java
@@ -60,22 +60,20 @@ public class DOCThumbnailer implements Thumbnailer {
 
     @Override
     public List<BufferedImage> getThumbnails(File input, List<Dimensions> dimensions) throws ThumbnailingException {
-        FileInputStream fis;
-        try {
-             fis = new FileInputStream(input);
+        try(FileInputStream fis = new FileInputStream(input)) {
+            return getThumbnails(fis, dimensions);
         } catch (FileNotFoundException e) {
             logger.error("Could not find file {}", input.getAbsolutePath());
             logger.error("With stack: ", e);
             throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new ThumbnailingException(e);
         }
-        return getThumbnails(fis, dimensions);
     }
 
     @Override
     public List<BufferedImage> getThumbnails(InputStream input, List<Dimensions> dimensions) throws ThumbnailingException {
-        HWPFDocument document;
-        try {
-            document = new HWPFDocument(input);
+        try (HWPFDocument document = new HWPFDocument(input)){
             byte[] htmlBytes = htmlBytesFromDoc(document);
             BufferedImage image = ThumbnailUtils.scaleHtmlToImage(htmlBytes, docPageDimensions(document));
             List<BufferedImage> results = new ArrayList<>();

--- a/thumbnails4j-docx/src/main/java/co/elastic/thumbnails4j/docx/DOCXThumbnailer.java
+++ b/thumbnails4j-docx/src/main/java/co/elastic/thumbnails4j/docx/DOCXThumbnailer.java
@@ -53,22 +53,21 @@ public class DOCXThumbnailer implements Thumbnailer {
 
     @Override
     public List<BufferedImage> getThumbnails(File input, List<Dimensions> dimensions) throws ThumbnailingException {
-        FileInputStream fis;
-        try {
-            fis = new FileInputStream(input);
+        try (FileInputStream fis = new FileInputStream(input)) {
+            return getThumbnails(fis, dimensions);
         } catch (FileNotFoundException e) {
             logger.error("Could not find file {}", input.getAbsolutePath());
             logger.error("With stack: ", e);
             throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new ThumbnailingException(e);
         }
-        return getThumbnails(fis, dimensions);
     }
 
     @Override
     public List<BufferedImage> getThumbnails(InputStream input, List<Dimensions> dimensions) throws ThumbnailingException {
         List<BufferedImage> results = new ArrayList<>();
-        try {
-            XWPFDocument docx = new XWPFDocument(input);
+        try (XWPFDocument docx = new XWPFDocument(input)){
             InputStream imageStream = docx.getProperties().getThumbnailImage();
             if (imageStream==null) {
                 byte[] htmlBytes = htmlBytesFromDocx(docx);

--- a/thumbnails4j-pdf/src/main/java/co/elastic/thumbnails4j/pdf/PDFThumbnailer.java
+++ b/thumbnails4j-pdf/src/main/java/co/elastic/thumbnails4j/pdf/PDFThumbnailer.java
@@ -58,9 +58,7 @@ public class PDFThumbnailer implements Thumbnailer {
 
     @Override
     public List<BufferedImage> getThumbnails(File input, List<Dimensions> dimensions) throws ThumbnailingException {
-        PDDocument document;
-        try {
-            document = PDDocument.load(input);
+        try (PDDocument document = PDDocument.load(input)) {
             return getThumbnails(document, dimensions);
         } catch (IOException e) {
             logger.error("Could not load input as PDF: ", e);
@@ -70,10 +68,7 @@ public class PDFThumbnailer implements Thumbnailer {
 
     @Override
     public List<BufferedImage> getThumbnails(InputStream input, List<Dimensions> dimensions) throws ThumbnailingException {
-
-        PDDocument document;
-        try {
-            document = PDDocument.load(input);
+        try (PDDocument document = PDDocument.load(input)) {
             return getThumbnails(document, dimensions);
         } catch (IOException e) {
             logger.error("Could not load input as PDF: ", e);

--- a/thumbnails4j-xlsx/src/main/java/co/elastic/thumbnails4j/xlsx/XLSXThumbnailer.java
+++ b/thumbnails4j-xlsx/src/main/java/co/elastic/thumbnails4j/xlsx/XLSXThumbnailer.java
@@ -50,8 +50,8 @@ public class XLSXThumbnailer implements Thumbnailer {
 
     @Override
     public List<BufferedImage> getThumbnails(File input, List<Dimensions> dimensions) throws ThumbnailingException {
-        try {
-            return getThumbnails(WorkbookFactory.create(input), dimensions);
+        try (Workbook workbook = WorkbookFactory.create(input)) {
+            return getThumbnails(workbook, dimensions);
         } catch (IOException e) {
             logger.error("Failed to parse XLSX: ", e);
             throw new ThumbnailingException(e);
@@ -60,8 +60,8 @@ public class XLSXThumbnailer implements Thumbnailer {
 
     @Override
     public List<BufferedImage> getThumbnails(InputStream input, List<Dimensions> dimensions) throws ThumbnailingException {
-        try {
-            return getThumbnails(WorkbookFactory.create(input), dimensions);
+        try (Workbook workbook = WorkbookFactory.create(input)) {
+            return getThumbnails(workbook, dimensions);
         } catch (IOException e) {
             logger.error("Failed to parse XLSX: ", e);
             throw new ThumbnailingException(e);


### PR DESCRIPTION
Prompted by a stackoverflow comment here: https://stackoverflow.com/a/70599310/2479282

> I tried using Thumbnails4j and it did generate the thumbnail, but I do see a warning in the console: Have you encountered that? I am using OpenJDK17, Spring Boot 2.6.7, Tomcat 9.... 2022-05-05 14:00:07.624 WARN 30628 --- [ Finalizer] org.apache.pdfbox.cos.COSDocument : Warning: You did not close a PDF Document

When I locally added `logback-classic` as a dep and then ran the PDFThumbnailer tests, I did actually see this warning show up in the test output. After a quick google, I saw: https://stackoverflow.com/a/4968514/2479282, which made me realize that we were not closing these documents. Further, PDFs weren't the only file types where we were not being judicious about closing our inputs. I went through them all, and added try-with-resources where able.