### PR TITLE
[CI] [Buildkite] Add Buildkite Pipeline and Catalog for Maven Build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,16 @@
+## 🏠/.buildkite/pipeline.yml
+# Primary pipeline for thumbnails4j
+# runs with every commit on a PR or branch
+
+agents:
+  image: "docker.elastic.co/swiftype/ent-search-ci-dev-base-20220124:latest"
+  ephemeralStorage: "20G"
+  memory: "4G"
+
+env:
+  CI: "true"
+
+steps:
+  - label: ":wrench: Maven Build"
+    command: "./mvnw clean verify"
+    timeout_in_minutes: 45

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,55 @@
+#########################################################################
+###################### catalog-info for ent-search ######################
+# Declare a Backstage Component for ent-search
+# When doing changes validate them using https://backstage.elastic.dev/entity-validation
+---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "thumbnails4j"
+  description: "thumbnails4j"
+  annotations:
+    backstage.io/source-location: "url:https://github.com/elastic/thumbnails4j/"
+    github.com/project-slug: "elastic/thumbnails4j"
+    github.com/team-slug: "elastic/enterprise-search"
+    buildkite.com/project-slug: "elastic/thumbnails4j"
+  tags:
+    - "thumbnails4j"
+    - "enterprise-search"
+    - "buildkite"
+spec:
+  type: "library"
+  system: "enterprise-search"
+  lifecycle: "production"
+  owner: "group:enterprise-search"
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-thumbnails4j
+  description: Buildkite Pipeline for thumbnails4j
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/thumbnails4j
+
+spec:
+  type: buildkite-pipeline
+  owner: group:enterprise-search
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: thumbnails4j
+    spec:
+      repository: elastic/thumbnails4j
+      pipeline_file: ".buildkite/pipeline.yml"
+      teams:
+        enterprise-search:
+          access_level: "MANAGE_BUILD_AND_READ"
+        everyone:
+          access_level: READ_ONLY
+


### PR DESCRIPTION
Adds the initial catalog and Buildkite scripts for replacing Jenkins as CI
