### PR TITLE
[CI] Temporarily Re-Add the settings.xml File for Deploy and Release

### DIFF
--- a/.ci/settings.xml
+++ b/.ci/settings.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ /*
+  ~  * Licensed to Elasticsearch B.V. under one or more contributor
+  ~  * license agreements. See the NOTICE file distributed with
+  ~  * this work for additional information regarding copyright
+  ~  * ownership. Elasticsearch B.V. licenses this file to you under
+  ~  * the Apache License, Version 2.0 (the "License"); you may
+  ~  * not use this file except in compliance with the License.
+  ~  * You may obtain a copy of the License at
+  ~  *
+  ~  *	http://www.apache.org/licenses/LICENSE-2.0
+  ~  *
+  ~  * Unless required by applicable law or agreed to in writing,
+  ~  * software distributed under the License is distributed on an
+  ~  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  * KIND, either express or implied.  See the License for the
+  ~  * specific language governing permissions and limitations
+  ~  * under the License.
+  ~  */
+  -->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+    <localRepository>/var/lib/jenkins/.m2/repository</localRepository>
+    <pluginGroups>
+        <pluginGroup>org.apache.maven.plugins</pluginGroup>
+        <pluginGroup>org.codehaus.mojo</pluginGroup>
+    </pluginGroups>
+    <servers>
+        <server>
+            <id>sonatype-nexus-snapshots</id>
+            <username>${env.SERVER_USERNAME}</username>
+            <password>${env.SERVER_PASSWORD}</password>
+        </server>
+        <server>
+            <id>sonatype-nexus-staging</id>
+            <username>${env.SERVER_USERNAME}</username>
+            <password>${env.SERVER_PASSWORD}</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.passphrase>${env.KEYPASS}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+</settings>


### PR DESCRIPTION
The `.ci/settings.xml` file is needed by the current Jenkins [release and deploy pipelines](https://github.com/elastic/infra/tree/df94d59cadcd7cc3d5bb26c501f965b8ea58e67b/ci/jjb/internal-ci/defs/elastic%2Bthumbnails4j). This was removed in a previous PR thinking we no longer needed it. This just temporarily restore this until we fully move to Buildkite.
