### PR TITLE
Actually check out the branch

### DIFF
--- a/.buildkite/scripts/git_setup.sh
+++ b/.buildkite/scripts/git_setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+export GIT_BRANCH=${BUILDKITE_BRANCH}
+
+git switch -
+git checkout $GIT_BRANCH
+git pull origin $GIT_BRANCH
+git config --local user.email 'elasticmachine@users.noreply.github.com'
+git config --local user.name 'Elastic Machine'

--- a/.buildkite/scripts/run_deploy_release.sh
+++ b/.buildkite/scripts/run_deploy_release.sh
@@ -17,6 +17,8 @@ SCRIPT_PATH="$(dirname "${BASH_SOURCE}")"
 BUILDKITE_PATH=$(realpath "$(dirname "$SCRIPT_PATH")")
 PROJECT_ROOT=$(realpath "$(dirname "$BUILDKITE_PATH")")
 
+source "${SCRIPT_PATH}/git_setup.sh"
+
 # Set Maven options
 export MAVEN_CONFIG="-V -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false $MAVEN_CONFIG"
 


### PR DESCRIPTION
Trying to release from buildkite, we were getting errors like:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project thumbnails4j: An error is occurred in the checkin process: Exception while executing SCM command. Detecting the current branch failed: fatal: ref HEAD is not a symbolic ref -> [Help 1]
--
```

The hope is that mimicing what we've done for other repos (`setup_git.sh` is stolen from connectors), we'll make sure that the job is actually in an ok spot to make changes.