### PR TITLE
[1.1] Add the nexus staging maven plugin (#39)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `1.1`:
 - [Add the nexus staging maven plugin (#39)](https://github.com/elastic/thumbnails4j/pull/39)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)