### PR TITLE
disable debug logging for release build

### DIFF
--- a/.buildkite/scripts/run_deploy_release.sh
+++ b/.buildkite/scripts/run_deploy_release.sh
@@ -38,7 +38,6 @@ elif [[ "${RUN_TYPE}" == "release" ]]; then
     $mvnw_command release:prepare release:perform \
       --settings .buildkite/mvn-settings.xml \
       -Darguments="-DskipTests" \
-      -e -X \
       --batch-mode 2>/dev/null
 else
     echo "Invalid RUN_TYPE: ${RUN_TYPE}. Nothing to do."


### PR DESCRIPTION
To keep the output from being too verbose, if it's working as expected.