### PR TITLE
ci: Use provided git credentials for release

### DIFF
--- a/.buildkite/mvn-settings.xml
+++ b/.buildkite/mvn-settings.xml
@@ -37,6 +37,11 @@
             <username>${env.SERVER_USERNAME}</username>
             <password>${env.SERVER_PASSWORD}</password>
         </server>
+        <server>
+            <id>github</id>
+            <username>${env.GIT_USER}</username>
+            <password>${env.GH_TOKEN}</password>
+        </server>
     </servers>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <scm>
         <connection>scm:git:git@github.com:elastic/thumbnails4j.git</connection>
-        <developerConnection>scm:git:git@github.com:elastic/thumbnails4j.git</developerConnection>
+        <developerConnection>scm:git:https://github.com/elastic/thumbnails4j.git</developerConnection>
         <url>https://github.com/elastic/thumbnails4j</url>
         <tag>HEAD</tag>
     </scm>
@@ -78,6 +78,7 @@
         <cglib.version>3.3.0</cglib.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.scm.id>github</project.scm.id>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- Moves changes from #48 to `main`
- The release now works - [commit](https://github.com/elastic/thumbnails4j/commit/acd85936bd437f2706fc8d40e010ba011781b6f9) 