### PR TITLE
[1.1] replace old nexus repos with new central server (#52)

### DIFF
--- a/.buildkite/mvn-settings.xml
+++ b/.buildkite/mvn-settings.xml
@@ -28,12 +28,7 @@
     </pluginGroups>
     <servers>
         <server>
-            <id>sonatype-nexus-snapshots</id>
-            <username>${env.SERVER_USERNAME}</username>
-            <password>${env.SERVER_PASSWORD}</password>
-        </server>
-        <server>
-            <id>sonatype-nexus-staging</id>
+            <id>central</id>
             <username>${env.SERVER_USERNAME}</username>
             <password>${env.SERVER_PASSWORD}</password>
         </server>

--- a/pom.xml
+++ b/pom.xml
@@ -281,14 +281,13 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>sonatype-nexus-staging</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
             <plugin>

--- a/thumbnails4j-all/pom.xml
+++ b/thumbnails4j-all/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-all</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-core/pom.xml
+++ b/thumbnails4j-core/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-core</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-doc/pom.xml
+++ b/thumbnails4j-doc/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-doc</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-docx/pom.xml
+++ b/thumbnails4j-docx/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-docx</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-image/pom.xml
+++ b/thumbnails4j-image/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-image</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-pdf/pom.xml
+++ b/thumbnails4j-pdf/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-pdf</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-pptx/pom.xml
+++ b/thumbnails4j-pptx/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-pptx</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-xls/pom.xml
+++ b/thumbnails4j-xls/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-xls</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/thumbnails4j-xlsx/pom.xml
+++ b/thumbnails4j-xlsx/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>thumbnails4j-xlsx</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `1.1`:
 - [replace old nexus repos with new central server (#52)](https://github.com/elastic/thumbnails4j/pull/52)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)